### PR TITLE
Implement smart contract functionality

### DIFF
--- a/zorp-contracts/src/IOwnable.sol
+++ b/zorp-contracts/src/IOwnable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+/// @dev See `Ownable` by OpenZeppelin
+interface IOwnable {
+    /* Public {{{ */
+        function owner() external view returns (address);
+    /* Public }}} */
+
+    /* Owner {{{ */
+        function renounceOwnership() external;
+        function transferOwnership(address newOwner) external;
+    /* Owner }}} */
+}

--- a/zorp-contracts/src/IZorpFactory.sol
+++ b/zorp-contracts/src/IZorpFactory.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import { IOwnable } from "./IOwnable.sol";
+
+/// @title Publicly accessible stored states within `ZorpFactory`
+interface IZorpFactory_Storage {
+    /* Constants {{{ */
+        function VERSION() external view returns (uint256);
+    /* Constants }}} */
+
+    /* Immutable {{{ */
+    /* Immutable }}} */
+
+    /* Mutable {{{ */
+        function latest_study_index() external view returns (uint256);
+        function studies(uint256) external view returns (address);
+    /* Mutable }}} */
+}
+
+/// @title Executable logic for `ZorpFactory`
+interface IZorpFactory_Functions {
+    /* Public {{{ */
+        function createStudy(address payable initialOwner, string memory encryptionKey) external payable returns (address);
+    /* Public }}} */
+
+    /* Owner {{{ */
+        function withdraw(address payable to, uint256 amount) external payable;
+    /* Owner }}} */
+
+    /* Viewable {{{ */
+        ///
+        function paginateSubmittedData(address study, uint256 start, uint256 limit) external view returns (string[] memory);
+
+        ///
+        function paginateStudies(uint256 start, uint256 limit) external view returns (address[] memory);
+    /* Viewable }}} */
+}
+
+interface IZorpFactory_Inherited is IOwnable {}
+
+/// @title On/Off chain consumers of `ZorpStudy` may wish to use this interface
+///
+/// ## On-chain example
+///
+/// ```solidity
+/// import { IZorpFactory } from "<NAME_SPACE>/src/IZorpFactory.sol";
+///
+/// contract View_ZorpFactory {
+///     getStudy(
+///         address factory,
+///         uint256 index
+///     ) external view returns (address) {
+///         return IZorpFactory(factory).studies(participant);
+///     }
+/// }
+/// ```
+interface IZorpFactory is IZorpFactory_Storage, IZorpFactory_Functions, IZorpFactory_Inherited {}

--- a/zorp-contracts/src/IZorpStudy.sol
+++ b/zorp-contracts/src/IZorpStudy.sol
@@ -84,6 +84,10 @@ interface IZorpStudy_Functions {
         /// @custom:throw `ZorpStudy: Failed trasfering balance`
         function endStudy() external payable;
     /* Owner }}} */
+
+    /* Viewable {{{ */
+        function paginateSubmittedData(uint256 start, uint256 limit) external view returns (string[] memory);
+    /* Viewable }}} */
 }
 
 /// @title On/Off chain consumers of `ZorpStudy` may wish to use this interface

--- a/zorp-contracts/src/IZorpStudy.sol
+++ b/zorp-contracts/src/IZorpStudy.sol
@@ -38,29 +38,50 @@ interface IZorpStudy_Storage {
         /// See `PARTICIPANT_STATUS__` constants
         function participant_status(address) external view returns (uint256);
 
-        /// See `Participant` data structure
-        function participants(uint256) external view returns (address, string memory);
+        /// @dev Index `0` should always point to `address(0)`
+        function participant_index(address) external view returns (uint256);
+
+        /// @dev Index `0` should always be empty
+        function submitted_data(uint256) external view returns (string memory);
     /* Mutable }}} */
 }
 
 /// @title Executable logic for `ZorpStudy`
 interface IZorpStudy_Functions {
     /* Public {{{ */
+        /// Store `ipfs_cid` in `ZorpStudy.submitted_data`
         ///
+        /// @custom:throw `ZorpStudy: Study not active`
+        /// @custom:throw `ZorpStudy: Invalid IPFS CID`
+        /// @custom:throw `ZorpStudy: Invalid message sender status`
         function submitData(string memory ipfs_cid) external;
 
+        /// Pay `ZorpStudy.participant_payout_amount` to `msg.sender`
         ///
+        /// @custom:throw `ZorpStudy: Study not finished`
+        /// @custom:throw `ZorpStudy: Invalid message sender status`
+        /// @custom:throw `ZorpStudy: Failed participant payout`
         function claimReward() external payable;
     /* Public }}} */
 
     /* Owner {{{ */
+        /// Set `PARTICIPANT_STATUS__INVALID` for address, then delete
+        /// associated storage in `participant_index` and `submitted_data`
         ///
+        /// @custom:throw `ZorpStudy: Study not active`
+        /// @custom:throw `ZorpStudy: Invalid participant status`
         function flagInvalidSubmission(address participant) external payable;
 
+        /// Set `STUDY_STATUS__ACTIVE` in `ZorpStudy.study_status`
         ///
+        /// @custom:throw `ZorpStudy: Study was previously activated`
         function startStudy() external payable;
 
+        /// Set `STUDY_STATUS__FINISHED` in `ZorpStudy.study_status`
         ///
+        /// @custom:throw `ZorpStudy: Study not active`
+        /// @custom:throw `ZorpStudy: Failed trasfering remainder`
+        /// @custom:throw `ZorpStudy: Failed trasfering balance`
         function endStudy() external payable;
     /* Owner }}} */
 }

--- a/zorp-contracts/src/IZorpStudy.sol
+++ b/zorp-contracts/src/IZorpStudy.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+/// @title Publicly accessible stored states within `ZorpStudy`
+interface IZorpStudy_Storage {
+    /* Constants {{{ */
+        function PARTICIPANT_STATUS__NA() external view returns (uint256);
+        function PARTICIPANT_STATUS__SUBMITTED() external view returns (uint256);
+        function PARTICIPANT_STATUS__PAID() external view returns (uint256);
+        function PARTICIPANT_STATUS__INVALID() external view returns (uint256);
+
+        function STUDY_STATUS__NA() external view returns (uint256);
+        function STUDY_STATUS__ACTIVE() external view returns (uint256);
+        function STUDY_STATUS__FINISHED() external view returns (uint256);
+    /* Constants }}} */
+
+    /* Immutable {{{ */
+        /// Pointer to factory contract that created this study
+        function creator() external view returns (address);
+    /* Immutable }}} */
+
+    /* Mutable {{{ */
+        /// Count of total submissions
+        function submissions() external view returns (uint256);
+
+        /// Count of invalid submissions
+        function invalidated() external view returns (uint256);
+
+        /// See `STUDY_STATUS__` constants
+        function study_status() external view returns (uint256);
+
+        /// See `ZorpStudy.endStudy` for when this is set and how
+        function participant_payout_amount() external view returns (uint256);
+
+        /// Pointer to GPG/PGP public key that submissions are to be encrypted with
+        function encryptionKey() external view returns (string memory);
+
+        /// See `PARTICIPANT_STATUS__` constants
+        function participant_status(address) external view returns (uint256);
+
+        /// See `Participant` data structure
+        function participants(uint256) external view returns (address, string memory);
+    /* Mutable }}} */
+}
+
+/// @title Executable logic for `ZorpStudy`
+interface IZorpStudy_Functions {
+    /* Public {{{ */
+        ///
+        function submitData(string memory ipfs_cid) external;
+
+        ///
+        function claimReward() external payable;
+    /* Public }}} */
+
+    /* Owner {{{ */
+        ///
+        function flagInvalidSubmission(address participant) external payable;
+
+        ///
+        function startStudy() external payable;
+
+        ///
+        function endStudy() external payable;
+    /* Owner }}} */
+}
+
+/// @title On/Off chain consumers of `ZorpStudy` may wish to use this interface
+///
+/// ## On-chain example
+///
+/// ```solidity
+/// import { IZorpStudy } from "<NAME_SPACE>/src/IZorpStudy.sol";
+///
+/// contract View_ZorpStudy {
+///     getParticipantStatus(
+///         address study,
+///         address participant
+///     ) external view returns (uint256) {
+///         return IZorpStudy(study).participant_status(participant);
+///     }
+/// }
+/// ```
+interface IZorpStudy is IZorpStudy_Storage, IZorpStudy_Functions {}

--- a/zorp-contracts/src/IZorpStudy.sol
+++ b/zorp-contracts/src/IZorpStudy.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
+import { IOwnable } from "./IOwnable.sol";
+
 /// @title Publicly accessible stored states within `ZorpStudy`
 interface IZorpStudy_Storage {
     /* Constants {{{ */
@@ -84,11 +86,9 @@ interface IZorpStudy_Functions {
         /// @custom:throw `ZorpStudy: Failed trasfering balance`
         function endStudy() external payable;
     /* Owner }}} */
-
-    /* Viewable {{{ */
-        function paginateSubmittedData(uint256 start, uint256 limit) external view returns (string[] memory);
-    /* Viewable }}} */
 }
+
+interface IZorpStudy_Inherited is IOwnable {}
 
 /// @title On/Off chain consumers of `ZorpStudy` may wish to use this interface
 ///
@@ -106,4 +106,4 @@ interface IZorpStudy_Functions {
 ///     }
 /// }
 /// ```
-interface IZorpStudy is IZorpStudy_Storage, IZorpStudy_Functions {}
+interface IZorpStudy is IZorpStudy_Storage, IZorpStudy_Functions, IZorpStudy_Inherited {}

--- a/zorp-contracts/src/ZorpFactory.sol
+++ b/zorp-contracts/src/ZorpFactory.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.17;
 
 import { ZorpStudy } from "./ZorpStudy.sol";
-// or "openzeppelin-contracts/contracts/access/Ownable.sol" if needed
-// import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-// import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract ZorpFactory {
+contract ZorpFactory is Ownable, ReentrancyGuard {
+    uint256 public constant VERSION = 1;
+
     // Optional: you could inherit Ownable if you want an admin for the factory.
     // e.g., `contract ZorpFactory is Ownable { ... }`
 
@@ -14,6 +15,8 @@ contract ZorpFactory {
     address[] public allStudies;
 
     event StudyCreated(address indexed studyAddress);
+
+    constructor (address payable initialOwner_) Ownable(initialOwner_) {}
 
     // createStudy is just a stub. In the future, it will take parameters:
     // e.g. merkleRoot, externalNullifierSub, externalNullifierClaim, tokenAddress, etc.
@@ -23,10 +26,10 @@ contract ZorpFactory {
     /// @param encryptionKey pointer to public GPG/PGP key
     /// @dev see `src/ZorpStudy.sol` -> `constructor`
     function createStudy(
-        address initialOwner,
+        address payable initialOwner,
         string memory encryptionKey
-    ) external returns (address) {
-        address newStudy = address(new ZorpStudy(
+    ) external payable nonReentrant returns (address) {
+        address newStudy = address((new ZorpStudy){value: msg.value}(
             initialOwner,
             encryptionKey
         ));

--- a/zorp-contracts/src/ZorpFactory.sol
+++ b/zorp-contracts/src/ZorpFactory.sol
@@ -2,24 +2,20 @@
 pragma solidity ^0.8.17;
 
 import { ZorpStudy } from "./ZorpStudy.sol";
+import { IZorpStudy } from "./IZorpStudy.sol";
+import { IZorpFactory_Functions } from "./IZorpFactory.sol";
+
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract ZorpFactory is Ownable, ReentrancyGuard {
+contract ZorpFactory is Ownable, ReentrancyGuard, IZorpFactory_Functions {
     uint256 public constant VERSION = 1;
-
-    // Optional: you could inherit Ownable if you want an admin for the factory.
-    // e.g., `contract ZorpFactory is Ownable { ... }`
-
-    // Array (or mapping) to track all deployed studies
-    address[] public allStudies;
+    uint256 public latest_study_index;
+    mapping(uint256 => address) public studies;
 
     event StudyCreated(address indexed studyAddress);
 
     constructor (address payable initialOwner_) Ownable(initialOwner_) {}
-
-    // createStudy is just a stub. In the future, it will take parameters:
-    // e.g. merkleRoot, externalNullifierSub, externalNullifierClaim, tokenAddress, etc.
 
     /// Wrapper to deploy a new ZorpStudy contract
     /// @param initialOwner owner or admin of study
@@ -34,13 +30,31 @@ contract ZorpFactory is Ownable, ReentrancyGuard {
             encryptionKey
         ));
 
-        allStudies.push(newStudy);
+        studies[++latest_study_index] = newStudy;
         emit StudyCreated(newStudy);
         return newStudy;
     }
 
-    // A getter to see how many studies have been created
-    function getStudyCount() external view returns (uint256) {
-        return allStudies.length;
+    function withdraw(address payable to, uint256 amount) external payable onlyOwner nonReentrant {
+        (bool success, ) = to.call{value: amount}("");
+        require(success, "ZorpFactory: Failed withdraw");
+    }
+
+    function paginateSubmittedData(address study, uint256 start, uint256 limit) external view returns (string[] memory) {
+        string[] memory results = new string[](limit);
+        for (uint256 i; i < limit;) {
+            results[i] = IZorpStudy(study).submitted_data(start++);
+            unchecked { ++i; }
+        }
+        return results;
+    }
+
+    function paginateStudies(uint256 start, uint256 limit) external view returns (address[] memory) {
+        address[] memory results = new address[](limit);
+        for (uint256 i; i < limit;) {
+            results[i] = studies[start++];
+            unchecked { ++i; }
+        }
+        return results;
     }
 }

--- a/zorp-contracts/src/ZorpFactory.sol
+++ b/zorp-contracts/src/ZorpFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "./ZorpStudy.sol";
+import { ZorpStudy } from "./ZorpStudy.sol";
 // or "openzeppelin-contracts/contracts/access/Ownable.sol" if needed
 
 contract ZorpFactory {

--- a/zorp-contracts/src/ZorpFactory.sol
+++ b/zorp-contracts/src/ZorpFactory.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.17;
 
 import { ZorpStudy } from "./ZorpStudy.sol";
 // or "openzeppelin-contracts/contracts/access/Ownable.sol" if needed
+// import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+// import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 contract ZorpFactory {
     // Optional: you could inherit Ownable if you want an admin for the factory.
@@ -15,13 +17,23 @@ contract ZorpFactory {
 
     // createStudy is just a stub. In the future, it will take parameters:
     // e.g. merkleRoot, externalNullifierSub, externalNullifierClaim, tokenAddress, etc.
-    function createStudy() external returns (address) {
-        // Deploy a new ZorpStudy contract (stubbed).
-        ZorpStudy newStudy = new ZorpStudy();
-        allStudies.push(address(newStudy));
 
-        emit StudyCreated(address(newStudy));
-        return address(newStudy);
+    /// Wrapper to deploy a new ZorpStudy contract
+    /// @param initialOwner owner or admin of study
+    /// @param encryptionKey pointer to public GPG/PGP key
+    /// @dev see `src/ZorpStudy.sol` -> `constructor`
+    function createStudy(
+        address initialOwner,
+        string memory encryptionKey
+    ) external returns (address) {
+        address newStudy = address(new ZorpStudy(
+            initialOwner,
+            encryptionKey
+        ));
+
+        allStudies.push(newStudy);
+        emit StudyCreated(newStudy);
+        return newStudy;
     }
 
     // A getter to see how many studies have been created

--- a/zorp-contracts/src/ZorpStudy.sol
+++ b/zorp-contracts/src/ZorpStudy.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.17;
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
+import { IZorpStudy_Functions } from "./IZorpStudy.sol";
+
 struct Participant {
     address account;
     string ipfs_cid;
 }
 
-/// @custom:link https://docs.ipfs.tech/how-to/address-ipfs-on-web/
-/// @custom:link https://github.com/openpgpjs/openpgpjs?tab=readme-ov-file#encrypt-and-decrypt-string-data-with-pgp-keys
-/// @custom:link https://github.com/ethereum/solidity/issues/11278 
+/// @title Track state of study and participant data
+/// @author S0AndS0.eth
+/// @custom:link https://www.elata.bio/
 contract ZorpStudy is Ownable, ReentrancyGuard {
     uint256 public constant PARTICIPANT_STATUS__NA = 0;
     uint256 public constant PARTICIPANT_STATUS__SUBMITTED = 1;
@@ -22,39 +24,18 @@ contract ZorpStudy is Ownable, ReentrancyGuard {
     uint256 public constant STUDY_STATUS__ACTIVE = 1;
     uint256 public constant STUDY_STATUS__FINISHED = 2;
 
-    /// Pointer to factory contract that created this study
     address public immutable creator;
 
-    /// Pointer to GPG/PGP public key that submissions are to be encrypted with
-    string public encryptionKey;
-
-    /// Submissions total
     uint256 public submissions;
-    /// Submissions that are invalidated
     uint256 public invalidated;
-    /// See `PARTICIPANT_STATUS__` constants
-    mapping(address => uint256) public participant_status;
-    /// See `Participant` data structure
-    mapping(uint256 => Participant) public participants;
 
-    /// See `STUDY_STATUS__` constants
     uint256 public study_status;
-
-    /// See `ZorpStudy.endStudy` for when this is set and how
     uint256 public participant_payout_amount;
 
-    // In the real version, you'd store:
-    //   - [X] ~~merkleRoot~~ GPG/PGP public key pointer; IPFS CID, Key fingerprint, email address, etc
-    //   - token type (ETH vs. native token)
-    //   - [X] admin or owner
-    //   - [ ] submission data, IPFS CID pointing to data encrypted with `this.encryptionKey` as recipient
+    string public encryptionKey;
 
-    // Minimal placeholder for submissions. In the future, you might store:
-    // struct Submission {
-    //     string ipfsCID;
-    //     bool valid;
-    // }
-    // Submission[] public submissions;
+    mapping(address => uint256) public participant_status;
+    mapping(uint256 => Participant) public participants;
 
     /// @param initialOwner_ owner or admin of study
     /// @param encryptionKey_ pointer to public GPG/PGP key
@@ -72,13 +53,10 @@ contract ZorpStudy is Ownable, ReentrancyGuard {
         creator = msg.sender;
     }
 
-    function submitData(
-        string memory ipfs_cid
-    ) external {
+    function submitData(string memory ipfs_cid) external {
         require(study_status == STUDY_STATUS__ACTIVE, "ZorpStudy: Study not active");
 
-        // TODO: https://github.com/ipfs/kubo/issues/4918
-        //       Investigate IPFS min/max byte lengths
+        // TODO: Investigate IPFS min/max byte lengths
         require(bytes(ipfs_cid).length > 0, "ZorpStudy: Invalid IPFS CID");
 
         require(participant_status[msg.sender] == PARTICIPANT_STATUS__NA, "ZorpStudy: Invalid status for message sender");
@@ -89,6 +67,16 @@ contract ZorpStudy is Ownable, ReentrancyGuard {
 
         participants[++submissions] = participant;
         participant_status[msg.sender] = PARTICIPANT_STATUS__SUBMITTED;
+    }
+
+    function claimReward() external payable nonReentrant {
+        require(study_status == STUDY_STATUS__FINISHED, "ZorpStudy: Study not finished");
+        require(participant_status[msg.sender] == PARTICIPANT_STATUS__SUBMITTED, "ZorpStudy: Invalid status for message sender");
+
+        participant_status[msg.sender] = PARTICIPANT_STATUS__PAID;
+
+        (bool success, ) = msg.sender.call{value: participant_payout_amount}("");
+        require(success, "ZorpStudy: Failed participant payout");
     }
 
     /// TODO: consider deleting `participant[_index_].ipfs_cid` and `.account` from contract storage
@@ -121,15 +109,5 @@ contract ZorpStudy is Ownable, ReentrancyGuard {
             (bool success, ) = msg.sender.call{value: balance}("");
             require(success, "ZorpStudy: Failed trasfering balance");
         }
-    }
-
-    function claimReward() external payable nonReentrant {
-        require(study_status == STUDY_STATUS__FINISHED, "ZorpStudy: Study not finished");
-        require(participant_status[msg.sender] == PARTICIPANT_STATUS__SUBMITTED, "ZorpStudy: Invalid status for message sender");
-
-        participant_status[msg.sender] = PARTICIPANT_STATUS__PAID;
-
-        (bool success, ) = msg.sender.call{value: participant_payout_amount}("");
-        require(success, "ZorpStudy: Failed participant payout");
     }
 }

--- a/zorp-contracts/src/ZorpStudy.sol
+++ b/zorp-contracts/src/ZorpStudy.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ZorpStudy {
     // In the real version, you'd store:

--- a/zorp-contracts/src/ZorpStudy.sol
+++ b/zorp-contracts/src/ZorpStudy.sol
@@ -106,4 +106,13 @@ contract ZorpStudy is Ownable, ReentrancyGuard {
             require(success, "ZorpStudy: Failed trasfering balance");
         }
     }
+
+    function paginateSubmittedData(uint256 start, uint256 limit) external view returns (string[] memory) {
+        string[] memory results = new string[](limit);
+        for (uint256 i; i < limit;) {
+            results[i] = submitted_data[start++];
+            unchecked { ++i; }
+        }
+        return results;
+    }
 }

--- a/zorp-contracts/src/ZorpStudy.sol
+++ b/zorp-contracts/src/ZorpStudy.sol
@@ -106,13 +106,4 @@ contract ZorpStudy is Ownable, ReentrancyGuard {
             require(success, "ZorpStudy: Failed trasfering balance");
         }
     }
-
-    function paginateSubmittedData(uint256 start, uint256 limit) external view returns (string[] memory) {
-        string[] memory results = new string[](limit);
-        for (uint256 i; i < limit;) {
-            results[i] = submitted_data[start++];
-            unchecked { ++i; }
-        }
-        return results;
-    }
 }

--- a/zorp-contracts/src/ZorpStudy.sol
+++ b/zorp-contracts/src/ZorpStudy.sol
@@ -4,12 +4,43 @@ pragma solidity ^0.8.17;
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
-contract ZorpStudy {
+struct Participant {
+    address account;
+    string ipfs_cid;
+}
+
+/// @custom:link https://docs.ipfs.tech/how-to/address-ipfs-on-web/
+/// @custom:link https://github.com/openpgpjs/openpgpjs?tab=readme-ov-file#encrypt-and-decrypt-string-data-with-pgp-keys
+/// @custom:link https://github.com/ethereum/solidity/issues/11278 
+contract ZorpStudy is Ownable, ReentrancyGuard {
+    uint256 public constant PARTICIPANT_STATUS__NA = 0;
+    uint256 public constant PARTICIPANT_STATUS__SUBMITTED = 1;
+    uint256 public constant PARTICIPANT_STATUS__INVALID = 2;
+
+    uint256 public constant STUDY_STATUS__NA = 0;
+    uint256 public constant STUDY_STATUS__ACTIVE = 1;
+    uint256 public constant STUDY_STATUS__FINISHED = 2;
+
+    /// Pointer to GPG/PGP public key that submissions are to be encrypted with
+    string public encryptionKey;
+
+    /// Submissions total
+    uint256 public submissions;
+    /// Submissions that are invalidated
+    uint256 public invalidated;
+    /// See `PARTICIPANT_STATUS__` constants
+    mapping(address => uint256) public participant_status;
+    /// See `Participant` data structure
+    mapping(uint256 => Participant) public participants;
+
+    /// See `STUDY_STATUS__` constants
+    uint256 public study_status;
+
     // In the real version, you'd store:
-    //   - merkleRoot
+    //   - [X] ~~merkleRoot~~ GPG/PGP public key pointer; IPFS CID, Key fingerprint, email address, etc
     //   - token type (ETH vs. native token)
-    //   - admin or owner
-    //   - submission data, etc.
+    //   - [X] admin or owner
+    //   - [ ] submission data, IPFS CID pointing to data encrypted with `this.encryptionKey` as recipient
 
     // Minimal placeholder for submissions. In the future, you might store:
     // struct Submission {
@@ -18,23 +49,54 @@ contract ZorpStudy {
     // }
     // Submission[] public submissions;
 
-    constructor() {
+    /// @param initialOwner_ owner or admin of study
+    /// @param encryptionKey_ pointer to public GPG/PGP key
+    constructor(
+        address initialOwner_,
+        string memory encryptionKey_
+    ) Ownable(initialOwner_) {
         // Future: accept constructor args (e.g. merkleRoot, externalNullifier).
+        encryptionKey = encryptionKey_;
     }
 
-    function submitData() external {
-        // Stub for users to submit data + proofs.
+    function submitData(
+        string memory ipfs_cid
+    ) external {
+        require(study_status == STUDY_STATUS__ACTIVE, "ZorpStudy: Study not active");
+
+        // TODO: https://github.com/ipfs/kubo/issues/4918
+        //       Investigate IPFS min/max byte lengths
+        require(bytes(ipfs_cid).length > 0, "ZorpStudy: Invalid IPFS CID");
+
+        require(participant_status[msg.sender] == PARTICIPANT_STATUS__NA, "ZorpStudy: Invalid status for message sender");
+
+        Participant memory participant;
+        participant.account = msg.sender;
+        participant.ipfs_cid = ipfs_cid;
+
+        participants[++submissions] = participant;
+        participant_status[msg.sender] = PARTICIPANT_STATUS__SUBMITTED;
     }
 
-    function flagInvalidSubmission(uint256 index) external {
-        // Admin can flag invalid data.
+    function flagInvalidSubmission(address participant) external payable onlyOwner {
+        require(study_status == STUDY_STATUS__ACTIVE, "ZorpStudy: Not active");
+        require(participant_status[participant] == PARTICIPANT_STATUS__SUBMITTED, "ZorpStudy: Invalid status for participant");
+        participant_status[participant] = PARTICIPANT_STATUS__INVALID;
+        ++invalidated;
     }
 
-    function endStudy() external {
-        // Admin ends the study, no more submissions.
+    function startStudy() external payable onlyOwner {
+        require(study_status == STUDY_STATUS__NA, "ZorpStudy: Study was previously activated");
+        study_status = STUDY_STATUS__ACTIVE;
     }
 
-    function claimReward() external {
-        // Participants can claim their reward here.
+    function endStudy() external payable onlyOwner {
+        require(study_status == STUDY_STATUS__ACTIVE, "ZorpStudy: Study not active");
+        study_status = STUDY_STATUS__FINISHED;
+    }
+
+    function claimReward() external payable {
+        uint status = participant_status[msg.sender];
+        require(status != PARTICIPANT_STATUS__NA && status != PARTICIPANT_STATUS__INVALID, "ZorpStudy: Invalid status for message sender");
     }
 }

--- a/zorp-contracts/test/ZorpTest.t.sol
+++ b/zorp-contracts/test/ZorpTest.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "forge-std/Test.sol";
-import "../src/ZorpFactory.sol";
-import "../src/ZorpStudy.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { ZorpFactory } from "../src/ZorpFactory.sol";
+import { Participant, ZorpStudy } from "../src/ZorpStudy.sol";
 
 contract ZorpTest is Test {
     ZorpFactory factory;

--- a/zorp-contracts/test/ZorpTest.t.sol
+++ b/zorp-contracts/test/ZorpTest.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
+// TODO: https://book.getfoundry.sh/forge/fuzz-testing
+
 import { Test } from "forge-std/Test.sol";
 
 import { ZorpFactory } from "../src/ZorpFactory.sol";
@@ -16,12 +18,144 @@ contract ZorpTest is Test {
 
     function testCreateStudy() public {
         // Call createStudy
-        address newStudy = factory.createStudy();
+        address newStudy = factory.createStudy(
+            address(this),
+            "0xDEADBEEF"
+        );
         // Check that we got a valid address
         assertTrue(newStudy != address(0), "Study address should not be zero");
 
         // Optionally check if allStudies array length is 1
         uint256 count = factory.getStudyCount();
         assertEq(count, 1, "There should be exactly one study created");
+
+        string memory encryptionKey = ZorpStudy(newStudy).encryptionKey();
+        assertEq(encryptionKey, "0xDEADBEEF", "Failed to retrieve store encryption key");
+    }
+
+    function test_ZorpStudy_startStudy() public {
+        address newStudy = factory.createStudy(
+            address(this),
+            "0xDEADBEEF"
+        );
+
+        ZorpStudy(newStudy).startStudy();
+        assertEq(ZorpStudy(newStudy).study_status(), ZorpStudy(newStudy).STUDY_STATUS__ACTIVE(), "Failed to set expected study status");
+
+        try ZorpStudy(newStudy).startStudy() {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Study was previously activated");
+        }
+    }
+
+    function test_ZorpStudy_endStudy() public {
+        address newStudy = factory.createStudy(
+            address(this),
+            "0xDEADBEEF"
+        );
+
+        try ZorpStudy(newStudy).endStudy() {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Study not active");
+        }
+
+        ZorpStudy(newStudy).startStudy();
+
+        ZorpStudy(newStudy).endStudy();
+        assertEq(ZorpStudy(newStudy).study_status(), ZorpStudy(newStudy).STUDY_STATUS__FINISHED(), "Failed to set expected study status");
+
+        try ZorpStudy(newStudy).endStudy() {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Study not active");
+        }
+    }
+
+    function test_ZorpStudy_submitData() public {
+        address newStudy = factory.createStudy(
+            address(this),
+            "0xDEADBEEF"
+        );
+
+        string memory ipfs_cid = "CAFEBABE";
+
+        try ZorpStudy(newStudy).submitData(ipfs_cid) {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Study not active");
+        }
+
+        ZorpStudy(newStudy).startStudy();
+
+        try ZorpStudy(newStudy).submitData("") {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Invalid IPFS CID");
+        }
+
+        ZorpStudy(newStudy).submitData(ipfs_cid);
+
+        try ZorpStudy(newStudy).submitData(ipfs_cid) {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Invalid status for message sender");
+        }
+
+        assertEq(ZorpStudy(newStudy).submissions(), 1, "Failed to increase submission count");
+
+        uint256 index = ZorpStudy(newStudy).submissions();
+        // TODO: maybe consider not using a struct?
+        (address stored_account, string memory stored_ipfs_cid) = ZorpStudy(newStudy).participants(index);
+        assertEq(stored_account, address(this), "Failed to retrieve expected participant account");
+        assertEq(stored_ipfs_cid, ipfs_cid, "Failed to retrieve expected participant IPFS CID");
+    }
+
+    function test_ZorpStudy_flagInvalidSubmission() public {
+        address newStudy = factory.createStudy(
+            address(this),
+            "0xDEADBEEF"
+        );
+
+        ZorpStudy(newStudy).startStudy();
+
+        try ZorpStudy(newStudy).flagInvalidSubmission(address(this)) {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Invalid status for participant");
+        }
+
+        string memory ipfs_cid = "CAFEBABE";
+        ZorpStudy(newStudy).submitData(ipfs_cid);
+
+        ZorpStudy(newStudy).flagInvalidSubmission(address(this));
+
+        try ZorpStudy(newStudy).flagInvalidSubmission(address(this)) {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Invalid status for participant");
+        }
+
+        try ZorpStudy(newStudy).submitData(ipfs_cid) {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Invalid status for message sender");
+        }
+
+        ZorpStudy(newStudy).endStudy();
+
+        try ZorpStudy(newStudy).submitData(ipfs_cid) {
+            revert("Failed to fail test");
+        } catch Error(string memory reason) {
+            assertEq(reason, "ZorpStudy: Study not active");
+        }
+
+        assertEq(ZorpStudy(newStudy).invalidated(), 1, "Failed to increase invalidated count");
+        assertEq(ZorpStudy(newStudy).participant_status(address(this)), ZorpStudy(newStudy).PARTICIPANT_STATUS__INVALID(), "Failed to invalidate participant");
+    }
+
+    function test_ZorpStudy_claimReward() public {
+        revert("TODO: This needs implmented then tested");
     }
 }

--- a/zorp-contracts/test/ZorpTest.t.sol
+++ b/zorp-contracts/test/ZorpTest.t.sol
@@ -191,4 +191,28 @@ contract ZorpTest is Test {
             assertEq(reason, "ZorpStudy: Invalid message sender status");
         }
     }
+
+    /// TODO: Investigate `[FAIL: EvmError: MemoryOOG]` when `data` is of size `>=2`
+    /// Might be a bug with `forge`, and/or friends, or a limitation of language
+    ///
+    /// - https://github.com/foundry-rs/foundry/issues/7490
+    /// - https://github.com/foundry-rs/foundry/issues/8383
+    /// - https://github.com/foundry-rs/foundry/issues/9536
+    function test_ZorpStudy_paginateSubmittedData() public {
+        address newStudy = createFundedStudy(ZORP_STUDY__OWNER, ZORP_STUDY__ENCRYPTION_KEY);
+
+        IZorpStudy(newStudy).startStudy();
+
+        IZorpStudy(newStudy).submitData(ZORP_STUDY__DATA__GOOD);
+
+        uint256 limit = 1;
+        string[] memory data = IZorpStudy(newStudy).paginateSubmittedData(1, limit);
+
+        string memory stored_ipfs_cid = data[0];
+        assertEq(stored_ipfs_cid, ZORP_STUDY__DATA__GOOD, "Failed to retrieve expected participant IPFS CID");
+
+        // for (uint256 index = 1; index < limit;) {
+        //     assertEq(data[index], "", "Failed to retrieve expected paginated IPFS CID");
+        // }
+    }
 }


### PR DESCRIPTION
I'm not too happy about onchain DevExp for `struct` when accessing from third-party contract, and implementing `ZorpStudy.claimReward` is something for my future self to figure out, but other than that most of the new features are ready for critique.