### PR TITLE
Add Sepolia Factory address and configs

### DIFF
--- a/zorp-frontend/README.md
+++ b/zorp-frontend/README.md
@@ -101,3 +101,16 @@ npm test:watch
 # npm test -- <File_Or_Test_Name>
 npm test -- InputFileToEncryptedMessage
 ```
+
+---
+
+## Deployment tips
+
+### Add chain
+
+The `./src/lib/constants/wagmiConfig.ts` file defines various data structures
+for configuring available chains.  In some cases, such as for `sepolia`, it may
+be possible to extend pre-existing defaults; and in other cases, such as
+`anvil`, more care must be taken to ensure all customizations are correctly
+configured.
+

--- a/zorp-frontend/__tests__/IrysFetchFileGpgKey.test.tsx
+++ b/zorp-frontend/__tests__/IrysFetchFileGpgKey.test.tsx
@@ -101,6 +101,7 @@ describe('IrysFetchFileGpgKey', () => {
 		render(
 			<QueryClientProvider client={queryClient}>
 				<IrysFetchFileGpgKey
+					addressStudy='0xa16E02E87b7454126E5E10d957A927A7F5B5d2be'
 					setState={(study_encryption_key) => {
 						expect(false).toBe(true);
 					}}

--- a/zorp-frontend/src/app/zorp/factory/create-study/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/create-study/page.tsx
@@ -28,7 +28,7 @@ export default function ZorpFactoryWriteCreateStudy() {
 	const [message, setMessage] = useState<string>('Info: connected wallet/provider required');
 	const [amount, setAmount] = useState<null | bigint>(null);
 
-	const { writeContractAsync } = useWriteContract({
+	const { writeContractAsync, isPending } = useWriteContract({
 		config: config.wagmiConfig,
 	});
 
@@ -133,7 +133,7 @@ export default function ZorpFactoryWriteCreateStudy() {
 			</div>
 
 			<ZorpFactoryAddressInput
-				disabled={isFetching}
+				disabled={isPending}
 				setState={setAddressFactory}
 			/>
 

--- a/zorp-frontend/src/app/zorp/factory/create-study/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/create-study/page.tsx
@@ -5,6 +5,7 @@ import type { BigNumber } from 'bignumber.js';
 import type { Key } from 'openpgp';
 import { useAccount, useWriteContract, useTransactionReceipt } from 'wagmi';
 import { useContracts } from '@/contexts/Contracts';
+import ZorpFactoryAddressInput from '@/components/contracts/ZorpFactoryAddressInput';
 import GpgEncryptionKeyFromInputFile from '@/components/features/GpgEncryptionKeyFromInputFile';
 import IrysBalanceGet from '@/components/features/IrysBalanceGet';
 import IrysUploadFileGpgKey from '@/components/features/IrysUploadFileGpgKey';
@@ -15,9 +16,11 @@ import * as config from '@/lib/constants/wagmiConfig';
  * @see {@link https://wagmi.sh/react/api/hooks/useTransactionReceipt}
  */
 export default function ZorpFactoryWriteCreateStudy() {
+	const addressFactoryAnvil = config.anvil.contracts.IZorpFactory[31337].address;
 	const className = '';
 
 	// TODO: consider reducing need of keeping bot `Key` and `File` in memory at same time
+	const [addressFactory, setAddressFactory] = useState<`0x${string}`>(addressFactoryAnvil);
 	const [gpgKey, setGpgKey] = useState<null | { file: File; key: Key; }>(null);
 	const [hash, setHash] = useState<undefined | `0x${string}`>(undefined);
 	const [irysBalance, setIrysBalance] = useState<null | bigint | number | BigNumber>(null);
@@ -86,7 +89,7 @@ export default function ZorpFactoryWriteCreateStudy() {
 		setMessage('Warn: starting blockchain write request to `ZorpFactory.createStudy`')
 		writeContractAsync({
 			abi: IZorpFactory.abi,
-			address: IZorpFactory.address,
+			address: addressFactory,
 			functionName: 'createStudy',
 			args: [
 				address.toString(),
@@ -99,6 +102,7 @@ export default function ZorpFactoryWriteCreateStudy() {
 		});
 	}, [
 		IZorpFactory,
+		addressFactory,
 		amount,
 		address,
 		irysUploadData,
@@ -127,6 +131,11 @@ export default function ZorpFactoryWriteCreateStudy() {
 			<div className="flex justify-center mt-8">
 				<ThemeSwitch />
 			</div>
+
+			<ZorpFactoryAddressInput
+				disabled={isFetching}
+				setState={setAddressFactory}
+			/>
 
 			<hr />
 			<GpgEncryptionKeyFromInputFile

--- a/zorp-frontend/src/app/zorp/factory/latest-study-index/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/latest-study-index/page.tsx
@@ -28,7 +28,7 @@ export default function ZorpFactoryReadLatestStudyIndex() {
 		bigint
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'latest_study_index',
 		args: [],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/paginate-participant-status/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/paginate-participant-status/page.tsx
@@ -29,7 +29,7 @@ export default function ZorpFactoryReadPaginateSubmittedData() {
 		number[]
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'paginateParticipantStatus',
 		args: [addressStudy, start, limit],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/paginate-studies/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/paginate-studies/page.tsx
@@ -27,7 +27,7 @@ export default function ZorpFactoryReadPaginateSubmittedData() {
 		Array<`0x${string}`>
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'paginateStudies',
 		args: [start, limit],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/paginate-submitted-data/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/paginate-submitted-data/page.tsx
@@ -29,7 +29,7 @@ export default function ZorpFactoryReadPaginateSubmittedData() {
 		string[]
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'paginateSubmittedData',
 		args: [addressStudy, start, limit],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/ref-factory-next/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/ref-factory-next/page.tsx
@@ -23,7 +23,7 @@ export default function ZorpFactoryReadRefFactoryNext() {
 		`0x${string}`
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'ref_factory_next',
 		args: [],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/ref-factory-previous/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/ref-factory-previous/page.tsx
@@ -23,7 +23,7 @@ export default function ZorpFactoryReadRefFactoryPrevious() {
 		`0x${string}`
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'ref_factory_previous',
 		args: [],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/studies/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/studies/page.tsx
@@ -33,7 +33,7 @@ export default function ZorpFactoryReadStudyAddress() {
 		`0x${string}`
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'studies',
 		args: [studyIndex],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/version/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/version/page.tsx
@@ -29,7 +29,7 @@ export default function ZorpFactoryReadVersion() {
 		bigint
 	>({
 		abi: IZorpFactory.abi,
-		address: IZorpFactory.address,
+		address: addressFactory,
 		functionName: 'VERSION',
 		args: [],
 		query: {

--- a/zorp-frontend/src/app/zorp/factory/withdraw/page.tsx
+++ b/zorp-frontend/src/app/zorp/factory/withdraw/page.tsx
@@ -62,7 +62,7 @@ export default function ZorpFactoryWriteWithdraw() {
 		try {
 			const response = await writeContractAsync({
 				abi: IZorpFactory.abi,
-				address: IZorpFactory.address,
+				address: addressFactory,
 				functionName: 'withdraw',
 				args: [addressTo, amount],
 			});

--- a/zorp-frontend/src/app/zorp/study/claim-reward/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/claim-reward/page.tsx
@@ -22,7 +22,7 @@ export default function ZorpStudyWriteClaimReward() {
 		return {
 			isAddressParticipantSet: address?.length === addressStudyAnvil.length && address.startsWith('0x'),
 			isAddressStudySet: addressStudy.length === addressStudyAnvil.length && addressStudy.startsWith('0x'),
-			isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!IZorpStudy?.address.length,
+			isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!addressStudy.length,
 		};
 	}, [
 		IZorpStudy,
@@ -39,7 +39,7 @@ export default function ZorpStudyWriteClaimReward() {
 		bigint | 0 | 1 | 2 | 3
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'participant_status',
 		args: [address],
 		query: {
@@ -58,7 +58,7 @@ export default function ZorpStudyWriteClaimReward() {
 		bigint | 0 | 1 | 2
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'study_status',
 		args: [],
 		query: {
@@ -99,7 +99,7 @@ export default function ZorpStudyWriteClaimReward() {
 		try {
 			const response = await writeContractAsync({
 				abi: IZorpStudy.abi,
-				address: IZorpStudy.address,
+				address: addressStudy,
 				functionName: 'claimReward',
 				args: [],
 			});
@@ -131,6 +131,7 @@ export default function ZorpStudyWriteClaimReward() {
 		}
 	}, [
 		IZorpStudy,
+		addressStudy,
 		assertsBlockchain,
 		assertsClient,
 		enabled,

--- a/zorp-frontend/src/app/zorp/study/creator/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/creator/page.tsx
@@ -21,7 +21,7 @@ export default function ZorpStudyReadCreator() {
 		`0x${string}`
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'creator',
 		args: [],
 		query: {
@@ -29,7 +29,7 @@ export default function ZorpStudyReadCreator() {
 						&& addressStudy.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/encryption-key-cid/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/encryption-key-cid/page.tsx
@@ -18,7 +18,7 @@ export default function ZorpStudyReadEncryptionKeyCid() {
 								&& addressStudy.startsWith('0x')
 								&& !!IZorpStudy?.abi
 								&& !!Object.keys(IZorpStudy.abi).length
-								&& !!IZorpStudy?.address.length;
+								&& !!addressStudy.length;
 
 	const { data: encryption_key_cid, isFetching, refetch } = useReadContract<
 		typeof IZorpStudy.abi,
@@ -28,7 +28,7 @@ export default function ZorpStudyReadEncryptionKeyCid() {
 		string
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'encryption_key',
 		args: [],
 		query: {

--- a/zorp-frontend/src/app/zorp/study/end-study/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/end-study/page.tsx
@@ -22,7 +22,7 @@ export default function ZorpStudyWriteEndStudy() {
 		return {
 			isAddressStudySet: addressStudy.length === addressStudyAnvil.length && addressStudy.startsWith('0x'),
 			isAddressWalletSet: !!address && address.length === addressStudyAnvil.length && address.startsWith('0x'),
-			isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!IZorpStudy?.address.length,
+			isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!addressStudy.length,
 		};
 	}, [
 		IZorpStudy,
@@ -39,7 +39,7 @@ export default function ZorpStudyWriteEndStudy() {
 		`0x${string}`
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'owner',
 		args: [],
 		query: {
@@ -55,7 +55,7 @@ export default function ZorpStudyWriteEndStudy() {
 		bigint | 0 | 1 | 2
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'study_status',
 		args: [],
 		query: {
@@ -106,7 +106,7 @@ export default function ZorpStudyWriteEndStudy() {
 		try {
 			const response = await writeContractAsync({
 				abi: IZorpStudy.abi,
-				address: IZorpStudy.address,
+				address: addressStudy,
 				functionName: 'endStudy',
 				args: [],
 			});
@@ -137,6 +137,7 @@ export default function ZorpStudyWriteEndStudy() {
 		}
 	}, [
 		IZorpStudy,
+		addressStudy,
 		assertsBlockchain,
 		assertsClient,
 		enabled,

--- a/zorp-frontend/src/app/zorp/study/flag-invalid-submission/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/flag-invalid-submission/page.tsx
@@ -25,7 +25,7 @@ export default function ZorpStudyWriteFlagInvalidSubmission() {
 		isAddressStudySet: addressStudy.length === addressStudyAnvil.length && addressStudy.startsWith('0x'),
 		isAddressParticipantSet: addressParticipant.length === addressStudyAnvil.length && addressParticipant.startsWith('0x'),
 		isAddressWalletSet: !!address && address.length === addressStudyAnvil.length && address.startsWith('0x'),
-		isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!IZorpStudy?.address.length,
+		isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!addressStudy.length,
 	};
 
 	const { data: owner, isFetching: isFetchingOwner } = useReadContract<
@@ -36,7 +36,7 @@ export default function ZorpStudyWriteFlagInvalidSubmission() {
 		`0x${string}`
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'owner',
 		args: [],
 		query: {
@@ -52,7 +52,7 @@ export default function ZorpStudyWriteFlagInvalidSubmission() {
 		bigint | 0 | 1 | 2 | 3
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'participant_status',
 		args: [addressParticipant],
 		query: {
@@ -71,7 +71,7 @@ export default function ZorpStudyWriteFlagInvalidSubmission() {
 		bigint | 0 | 1 | 2
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'study_status',
 		args: [],
 		query: {
@@ -117,7 +117,7 @@ export default function ZorpStudyWriteFlagInvalidSubmission() {
 		try {
 			const response = await writeContractAsync({
 				abi: IZorpStudy.abi,
-				address: IZorpStudy.address,
+				address: addressStudy,
 				functionName: 'flagInvalidSubmission',
 				args: [addressParticipant],
 			});
@@ -152,6 +152,7 @@ export default function ZorpStudyWriteFlagInvalidSubmission() {
 		setIsFetching,
 		IZorpStudy,
 		addressParticipant,
+		addressStudy,
 		setReceipt,
 		writeContractAsync,
 	]);

--- a/zorp-frontend/src/app/zorp/study/index-participant/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/index-participant/page.tsx
@@ -26,7 +26,7 @@ export default function ZorpStudyReadParticipantAddress() {
 		bigint | number
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'participant_address',
 		args: [indexParticipant],
 		query: {
@@ -35,7 +35,7 @@ export default function ZorpStudyReadParticipantAddress() {
 						&& Number.isNaN(indexParticipant)
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/invalidated/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/invalidated/page.tsx
@@ -23,7 +23,7 @@ export default function ZorpStudyReadInvalidated() {
 		bigint
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'invalidated',
 		args: [],
 		query: {
@@ -31,7 +31,7 @@ export default function ZorpStudyReadInvalidated() {
 						&& addressStudy.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/participant-index/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/participant-index/page.tsx
@@ -26,7 +26,7 @@ export default function ZorpStudyReadParticipantIndex() {
 		bigint | number
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'participant_index',
 		args: [addressParticipant],
 		query: {
@@ -36,7 +36,7 @@ export default function ZorpStudyReadParticipantIndex() {
 						&& addressParticipant.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/participant-payout-amount/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/participant-payout-amount/page.tsx
@@ -23,7 +23,7 @@ export default function ZorpStudyReadParticipantPayoutAmount() {
 		bigint
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'participant_payout_amount',
 		args: [],
 		query: {
@@ -31,7 +31,7 @@ export default function ZorpStudyReadParticipantPayoutAmount() {
 						&& addressStudy.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/participant-status/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/participant-status/page.tsx
@@ -26,7 +26,7 @@ export default function ZorpStudyReadParticipantStatus() {
 		bigint | 0 | 1 | 2 | 3
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'participant_status',
 		args: [addressParticipant],
 		query: {
@@ -36,7 +36,7 @@ export default function ZorpStudyReadParticipantStatus() {
 						&& addressParticipant.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/start-study/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/start-study/page.tsx
@@ -22,7 +22,7 @@ export default function ZorpStudyWriteStartStudy() {
 	const assertsClient = {
 		isAddressStudySet: addressStudy.length === addressStudyAnvil.length && addressStudy.startsWith('0x'),
 		isAddressWalletSet: !!address && address.length === addressStudyAnvil.length && address.startsWith('0x'),
-		isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!IZorpStudy?.address.length,
+		isContractStudySet: !!IZorpStudy?.abi && !!Object.keys(IZorpStudy.abi).length && !!addressStudy.length,
 	};
 
 	const { data: owner, isFetching: isFetchingOwner } = useReadContract<
@@ -33,7 +33,7 @@ export default function ZorpStudyWriteStartStudy() {
 		`0x${string}`
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'owner',
 		args: [],
 		query: {
@@ -49,7 +49,7 @@ export default function ZorpStudyWriteStartStudy() {
 		bigint | 0 | 1 | 2
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'study_status',
 		args: [],
 		query: {
@@ -88,7 +88,7 @@ export default function ZorpStudyWriteStartStudy() {
 		try {
 			const response = await writeContractAsync({
 				abi: IZorpStudy.abi,
-				address: IZorpStudy.address,
+				address: addressStudy,
 				functionName: 'startStudy',
 				args: [],
 			});
@@ -120,6 +120,7 @@ export default function ZorpStudyWriteStartStudy() {
 		}
 	}, [
 		IZorpStudy,
+		addressStudy,
 		enabled,
 		setIsFetching,
 		setReceipt,

--- a/zorp-frontend/src/app/zorp/study/study-status/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/study-status/page.tsx
@@ -22,7 +22,7 @@ export default function ZorpStudyReadStudyStatus() {
 		bigint | 0 | 1 | 2
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'study_status',
 		args: [],
 		query: {

--- a/zorp-frontend/src/app/zorp/study/submissions/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/submissions/page.tsx
@@ -22,7 +22,7 @@ export default function ZorpStudyReadSubmissions() {
 		bigint
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'submissions',
 		args: [],
 		query: {
@@ -30,7 +30,7 @@ export default function ZorpStudyReadSubmissions() {
 						&& addressStudy.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length,
+						&& !!addressStudy.length,
 		},
 	});
 

--- a/zorp-frontend/src/app/zorp/study/submit-data/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/submit-data/page.tsx
@@ -5,6 +5,7 @@ import type { BigNumber } from 'bignumber.js';
 import type { Key } from 'openpgp';
 import { useAccount, useWriteContract } from 'wagmi';
 import { useContracts } from '@/contexts/Contracts';
+import ZorpStudyAddressInput from '@/components/contracts/ZorpStudyAddressInput';
 import EncryptedMessageFromInputFile from '@/components/features/EncryptedMessageFromInputFile';
 import GpgEncryptionKeyFromInputFile from '@/components/features/GpgEncryptionKeyFromInputFile';
 import IrysBalanceGet from '@/components/features/IrysBalanceGet';
@@ -15,6 +16,9 @@ import * as config from '@/lib/constants/wagmiConfig';
 
 export default function ZorpStudySubmitData() {
 	const className = '';
+
+	const addressStudyAnvil = config.anvil.contracts.IZorpStudy[31337].address;
+	const [addressStudy, setAddressStudy] = useState<`0x${string}`>(addressStudyAnvil);
 
 	// TODO: consider reducing need of keeping both `Key` and `File` in memory at same time
 	const [gpgKey, setGpgKey] = useState<null | { file: File; key: Key; }>(null);
@@ -57,7 +61,7 @@ export default function ZorpStudySubmitData() {
 			return;
 		}
 
-		if (!IZorpStudy?.abi || !Object.keys(IZorpStudy.abi).length || !IZorpStudy?.address.length) {
+		if (!IZorpStudy?.abi || !Object.keys(IZorpStudy.abi).length || !addressStudy.length) {
 			const message = 'Error: no contracts found for current chain';
 			console.error('ZorpStudySubmitData', {message});
 			setMessage(message)
@@ -66,7 +70,7 @@ export default function ZorpStudySubmitData() {
 
 		writeContractAsync({
 			abi: IZorpStudy.abi,
-			address: IZorpStudy.address,
+			address: addressStudy,
 			functionName: 'submitData',
 			args: [
 				address.toString(),
@@ -80,6 +84,7 @@ export default function ZorpStudySubmitData() {
 	}, [
 		IZorpStudy,
 		address,
+		addressStudy,
 		irysUploadData,
 		isConnected,
 		writeContractAsync,
@@ -110,7 +115,14 @@ export default function ZorpStudySubmitData() {
 
 			<hr />
 
-			<IrysFetchFileGpgKey setState={setEncryptionKey} />
+			<ZorpStudyAddressInput
+				disabled={!isConnected}
+				setState={setAddressStudy}
+			/>
+
+			<hr />
+
+			<IrysFetchFileGpgKey addressStudy={addressStudy} setState={setEncryptionKey} />
 
 			<hr />
 
@@ -133,7 +145,7 @@ export default function ZorpStudySubmitData() {
 			<hr />
 
 			<label className={`zorp_study_submit_data zorp_study_submit_data__label ${className}`}>
-				Zorp Factory Create Study
+				Zorp Submit Study Data
 			</label>
 
 			<button
@@ -144,7 +156,8 @@ export default function ZorpStudySubmitData() {
 					console.warn('ZorpStudySubmitData', {event});
 					handleZorpStudySubmitData();
 				}}
-			>Zorp Factory Create Study</button>
+				disabled={!isConnected}
+			>Zorp Submit Study Data</button>
 
 			<span className={`zorp_study_submit_data zorp_study_submit_data__span ${className}`}>{message}</span>
 

--- a/zorp-frontend/src/app/zorp/study/submitted-data/page.tsx
+++ b/zorp-frontend/src/app/zorp/study/submitted-data/page.tsx
@@ -25,7 +25,7 @@ export default function ZorpStudyReadSubmittedData() {
 		string
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		functionName: 'submitted_data',
 		args: [index],
 		query: {
@@ -33,7 +33,7 @@ export default function ZorpStudyReadSubmittedData() {
 						&& addressStudy.startsWith('0x')
 						&& !!IZorpStudy?.abi
 						&& !!Object.keys(IZorpStudy.abi).length
-						&& !!IZorpStudy?.address.length
+						&& !!addressStudy.length
 						&& !!index
 						&& index > 0
 		},

--- a/zorp-frontend/src/components/features/IrysFetchFileGpgKey.tsx
+++ b/zorp-frontend/src/components/features/IrysFetchFileGpgKey.tsx
@@ -10,9 +10,11 @@ import * as wagmiConfig from '@/lib/constants/wagmiConfig';
 
 export default function IrysFetchFileGpgKey({
 	className = '',
+	addressStudy,
 	setState,
 }: {
 	className?: string;
+	addressStudy: `0x${string}`,
 	setState: (study_encryption_key: null | { key: Key; response: Response; }) => void;
 }) {
 	const [messageReadContract, setMessageReadContract] = useState<string>('Info: Waiting for ZorpStudy.encryptionKey() read to return something...');
@@ -28,7 +30,7 @@ export default function IrysFetchFileGpgKey({
 		string
 	>({
 		abi: IZorpStudy.abi,
-		address: IZorpStudy.address,
+		address: addressStudy,
 		config: wagmiConfig.wagmiConfig,
 		functionName: 'encryption_key',
 	});

--- a/zorp-frontend/src/lib/constants/wagmiConfig.ts
+++ b/zorp-frontend/src/lib/constants/wagmiConfig.ts
@@ -2,7 +2,7 @@ import '@rainbow-me/rainbowkit/styles.css';
 import { defineChain } from 'viem';
 import { chainConfig } from 'viem/op-stack';
 import { http, fallback } from 'wagmi';
-import { arbitrum, base, mainnet, sepolia } from 'wagmi/chains';
+import { arbitrum, base, mainnet, sepolia as sepoliaDefaults } from 'wagmi/chains';
 import { getDefaultConfig, WalletList } from '@rainbow-me/rainbowkit';
 import {
   coinbaseWallet,
@@ -54,6 +54,12 @@ const RPC_URLS = {
     'http://localhost:8545', // Default RPC
     'http://localhost:8545', // Public Node
     'http://localhost:8545', // Llama
+  ],
+  // TODO: double-check URLs are correct
+  SEPOLIA: [
+    'https://sepolia.base.org', // Default RPC
+    'https://sepolia.base.org', // Public Node
+    'https://sepolia.base.org', // Llama
   ],
 } as const;
 
@@ -158,6 +164,30 @@ export const anvil = /*#__PURE__*/ defineChain({
 	sourceId: 31337,
 });
 
+/**
+ * @see {@link https://docs.base.org/chain/network-information}
+ * @see {@link https://1.x.wagmi.sh/react/chains}
+ */
+export const sepolia = /*#__PURE__*/ defineChain({
+	...sepoliaDefaults,
+	contracts: {
+		IZorpFactory: {
+			84532: {
+				address: '0xD5B17B23c46a3514A2161Db8a405b0688a9d06cC',
+				abi: IZorpFactory.abi,
+			},
+		},
+		IZorpStudy: {
+			84532: {
+				// TODO: update `address` once a test study has been created
+				address: '0xa16E02E87b7454126E5E10d957A927A7F5B5d2be',
+				abi: IZorpStudy.abi,
+			},
+		},
+	},
+	sourceId: 84532,
+});
+
 export const wagmiConfig = getDefaultConfig({
   appName: 'Next dApp Template',
   projectId: projectId,
@@ -167,7 +197,9 @@ export const wagmiConfig = getDefaultConfig({
     arbitrum,
     base,
     anvil,
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : []),
+    // TODO: re-enable `process` check after testing test-net
+    sepolia,
+    // ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : []),
   ],
   transports,
   ssr: true, // If your dApp uses server side rendering (SSR)


### PR DESCRIPTION
Prior to accepting this PR, please be sure to double-check new `TODO` comments via;

```bash
grep -in -- todo zorp-frontend/src/lib/constants/wagmiConfig.ts 
```

...  Specifically;

```
58:  // TODO: double-check URLs are correct
182:                            // TODO: update `address` once a test study has been created
200:    // TODO: re-enable `process` check after testing test-net
```

Additionally it seems `vitest` and GitHub Actions ain't playing nice, specifically "Test frontend" job is intermittently popping time-out errors...  Intermittently, meaning rerunning sometimes results in things working...  For which I'm inclined to blame GitHub Actions and/or `vitest`, because the `zorp-frontend/vitest.config.mts` time-out defined _should_ be high enough to allow things to complete :shrug:

**Links and routes to test;**

- [GitHub Actions](https://github.com/Digital-Mercenaries/zorp/actions/runs/14868702660)
- [GitHub Pages](https://digital-mercenaries.github.io/zorp/)
  - [`zorp/factory/create-study`](https://digital-mercenaries.github.io/zorp/zorp/factory/create-study) _should_ return an address for a new study
  - [`zorp/study/start-study`](https://digital-mercenaries.github.io/zorp/zorp/study/start-study) "ZORP Study Address:" **must** be pasted into text box from previous step, and is required before participants may participate
  - [`zorp/study/submit-data`](https://digital-mercenaries.github.io/zorp/zorp/study/submit-data) probably best to call this multiple times
  - [`zorp/study/flag-invalid-submission`](https://digital-mercenaries.github.io/zorp/zorp/study/flag-invalid-submission) probably wise to call this at least once
  - [`zorp/study/end-study`](https://digital-mercenaries.github.io/zorp/zorp/study/end-study) _should_ prevent further participation and define reward payout amount
  - [`zorp/study/claim-reward`](https://digital-mercenaries.github.io/zorp/zorp/study/claim-reward) _should_ only pay valid participant(s)

**Enumerating all integration routes tip;**

```bash
find zorp-frontend/src/app/zorp/ -type f -print |
  sed '{
    s@zorp-frontend/src/app/@https://digital-mercenaries.github.io/zorp/@;
    s@/page.tsx@@;
  }' 
```

> :warning: the NextJS/ReactJS router does not like trailing slashes, so if ya get a "404 Page not found" that's often been the reason for me ;-)

**Change log summary;**

- `zorp-frontend/src/lib/contracts/wagmiConfig.ts` added configs for Sepolia Factory contract
- `zorp-frontend/src/app/zorp/study/` fixed bugs involving missus of `IZorpStudy.address` and, where missing, added element/state for setting `ZorpStudy` address...  oh the embarrassment :facepalm:
- `zorp-frontend/src/app/zorp/factory/` fixed bugs involving missus of `IZorpFactory.address` :facepalm:
- `zorp-frontend/README.md` add sub-section for hinting how to support/configure more chains
